### PR TITLE
Types Improvement

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -172,8 +172,8 @@ export type ReduxRouterProps = {
   history: History
   basename?: string
   children: React.ReactNode
-  enableTimeTravelling: boolean
-  routerSelector: ReduxRouterSelector
+  enableTimeTravelling?: boolean
+  routerSelector?: ReduxRouterSelector
 }
 
 const development = process.env.NODE_ENV === 'development'


### PR DESCRIPTION
After transition to a Functional Component, two component properties (`enableTimeTravelling`, `routerSelector`) became **required**.

In the previous implementation (**Class Component**) this was handled by the `react` types since the `defaultProps` object contained these properties.
Now, using a **Functional Component**, these properties should be explicitly marked as **optional** to comply the previous library typing.