### PR TITLE
Fix `UpdateLocationActions` type

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -143,7 +143,7 @@ export function createRouterMiddleware(history: History): Middleware {
       }
     }
 
-    if (action.payload.asEffect) {
+    if (action.payload.asEffect === true) {
       queueMicrotask(callHistoryMethod)
       return
     }
@@ -173,7 +173,7 @@ export function createRouterReducer(history: History): Reducer<ReduxRouterState>
   * has transitioned to.
   */
   return (state = initialRouterState, action: LocationChangeAction | AnyAction) => {
-    return matchLocationChangeAction(action) ? action.payload : state
+    return matchLocationChangeAction(action) === true ? action.payload : state
   }
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -28,6 +28,9 @@ export const onLocationChanged = (location: Location, action: Action): LocationC
   payload: { location, action },
 })
 
+export function matchLocationChangeAction(action: AnyAction): action is LocationChangeAction {
+  return action.type === ROUTER_ON_LOCATION_CHANGED
+}
 
 /**
  * This action type will be dispatched by the history actions below.
@@ -50,6 +53,10 @@ function updateLocation<M extends Methods>(method: M, asEffect = true) {
     type: ROUTER_CALL_HISTORY_METHOD,
     payload: { method, args, asEffect },
   })
+}
+
+export function matchUpdateLocationActions(action: AnyAction): action is UpdateLocationActions {
+  return action.type === ROUTER_CALL_HISTORY_METHOD
 }
 
 /**
@@ -108,7 +115,7 @@ export type RouterActions = LocationChangeAction | UpdateLocationActions
 
 export function createRouterMiddleware(history: History): Middleware {
   return () => next => (action: UpdateLocationActions & AnyAction) => {
-    if (action.type === ROUTER_CALL_HISTORY_METHOD) {
+    if (matchUpdateLocationActions(action)) {
       if (action.payload.asEffect === true) {
         queueMicrotask(() => history[action.payload.method](...action.payload.args))
       } else {
@@ -141,7 +148,7 @@ export function createRouterReducer(history: History): Reducer<ReduxRouterState>
   * has transitioned to.
   */
   return (state = initialRouterState, action: LocationChangeAction | AnyAction) => {
-    return action.type === ROUTER_ON_LOCATION_CHANGED ? action.payload : state
+    return matchLocationChangeAction(action) ? action.payload : state
   }
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,4 @@
-import { Action, History, Location, To } from 'history'
+import { Action, History, Location } from 'history'
 import React, { useEffect, useRef } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { Router } from 'react-router'
@@ -118,7 +118,7 @@ export type RouterActions = LocationChangeAction | UpdateLocationActions
 // Middleware
 
 export function createRouterMiddleware(history: History): Middleware {
-  return () => next => (action: UpdateLocationActions | AnyAction) => {
+  return () => next => (action) => {
     if (!matchUpdateLocationActions(action)) {
       return next(action)
     }
@@ -132,11 +132,13 @@ export function createRouterMiddleware(history: History): Middleware {
           history[action.payload.method]()
           break
         case 'go':
-          history[action.payload.method](...action.payload.args as [number])
+          history[action.payload.method](...action.payload.args)
           break
         case 'push':
+          history[action.payload.method](...action.payload.args)
+          break
         case 'replace':
-          history[action.payload.method](...action.payload.args as [To, any])
+          history[action.payload.method](...action.payload.args)
           break
       }
     }


### PR DESCRIPTION
Previously the type was an intersection of all methods which typescript unexpectedly narrows to a single `forward` action. But instead of an intersection we actually want a union to describe _one of_ the actions instead _all_ the actions.

This problem occurred as I used `Observable<RouterActions>` as the return type of an `redux-observable` epic.

Fixing the type caused problems on another unexpected intersection type for the action in the middleware. Fixing this one too caused typescript to be not able to narrow the argument types for the history method anymore. To help typescript here I added a switch block which handles each tuple type separately. A bit more code than before but I saw no other solution.

I also added to type guards `matchLocationChangeAction` and `matchUpdateLocationActions` which I used to match the actions and help typescript to determine the correct types. I also exported them to be able to use them in user code with `@reduxjs/toolkit` or `redux-observable`.