### PR TITLE
fix: fix type checking issues related to redux v5 support

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -131,6 +131,8 @@ export function createRouterMiddleware(history: History): Middleware {
       // each argument constellation separately
       switch(method) {
         case 'back':
+          history.back()
+          break
         case 'forward':
           history.forward()
           break

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -123,8 +123,8 @@ export function createRouterMiddleware(history: History): Middleware {
       return next(action)
     }
 
-    const updateLocationAction = action as UpdateLocationActions;
-    const { method, args } = updateLocationAction.payload;
+    const updateLocationAction = action as UpdateLocationActions
+    const { method, args } = updateLocationAction.payload
 
     const callHistoryMethod = () => {
       // Typescript is not able to narrow the arguments types correctly, so we need to handle


### PR DESCRIPTION
- The PR addresses the [existing type checking issues](https://github.com/lagunovsky/redux-react-router/actions/runs/7701523225/job/20987751381#step:4:54) related to redux v5 support #21.
- Deprecated `AnyAction` has been replaced with `UnknownAction`.