### PR TITLE
deps: support React 19

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ A Redux binding for React Router
 ## Main features
 
 - Synchronize router state with redux store through uni-directional flow (i.e. history -> store -> router -> components).
-- Supports [React Router v6](https://github.com/ReactTraining/react-router/tree/dev) and [History v5](https://github.com/ReactTraining/history)
+- Supports [React Router v7](https://github.com/remix-run/react-router/tree/main) and [History v5](https://github.com/remix-run/history)
 - Supports functional component hot reloading while preserving state.
-- Dispatching of history methods (`push`, `replace`, `go`, `back`, `forward`) works for both [redux-thunk](https://github.com/gaearon/redux-thunk)
-  and [redux-saga](https://github.com/yelouafi/redux-saga).
+- Dispatching of history methods (`push`, `replace`, `go`, `back`, `forward`) works for both [redux-thunk](https://github.com/reduxjs/redux-thunk)
+  and [redux-saga](https://github.com/redux-saga/redux-saga).
 - Nested children can access routing state such as the current location directly with `react-redux`'s `connect`.
 - Supports time traveling in Redux DevTools.
 - TypeScript

--- a/package.json
+++ b/package.json
@@ -26,16 +26,16 @@
   },
   "peerDependencies": {
     "history": "^5",
-    "react": "^16.8 || ^17 || ^18",
-    "react-dom": "^16.8 || ^17 || ^18",
+    "react": "^16.8 || ^17 || ^18 || ^19",
+    "react-dom": "^16.8 || ^17 || ^18 || ^19",
     "react-redux": "^6 || ^7 || ^8 || ^9",
-    "react-router": "^6",
+    "react-router": "^6 || ^7",
     "redux": "^4 || ^5"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^14.1.0",
     "@types/node": "^18.7.18",
-    "@types/react": "^18.0.20",
+    "@types/react": "^19.1.4",
     "install-peers-cli": "^2.2.0",
     "rollup": "^2.79.0",
     "rollup-plugin-peer-deps-external": "^2.2.4",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -208,7 +208,7 @@ export type ReduxRouterProps = {
 
 export function ReduxRouter({ routerSelector = reduxRouterSelector, ...props }: ReduxRouterProps) {
   const dispatch = useDispatch()
-  const skipHistoryChange = useRef<boolean>()
+  const skipHistoryChange = useRef<boolean>(undefined)
   const state = useSelector(routerSelector)
 
   useEffect(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -46,18 +46,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.7.18.tgz#633184f55c322e4fb08612307c274ee6d5ed3154"
   integrity sha512-m+6nTEOadJZuTPkKR/SYK3A2d7FZrgElol9UP1Kae90VVU4a6mxnPuLiIW1m4Cq4gZ/nWb9GrdVXJCoCazDAbg==
 
-"@types/prop-types@*":
-  version "15.7.5"
-  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.5.tgz#5f19d2b85a98e9558036f6a3cacc8819420f05cf"
-  integrity sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==
-
-"@types/react@^18.0.20":
-  version "18.0.20"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.20.tgz#e4c36be3a55eb5b456ecf501bd4a00fd4fd0c9ab"
-  integrity sha512-MWul1teSPxujEHVwZl4a5HxQ9vVNsjTchVA+xRqv/VYGCuKGAU6UhfrTdF5aBefwD1BHUD8i/zq+O/vyCm/FrA==
+"@types/react@^19.1.4":
+  version "19.1.4"
+  resolved "https://tr1.jfrog.io/tr1/api/npm/npm/@types/react/-/react-19.1.4.tgz#4d125f014d6ac26b4759775698db118701e314fe"
+  integrity sha512-EB1yiiYdvySuIITtD5lhW4yPyJ31RkJkkDw794LaQYrxCSaQV/47y5o1FMC4zF9ZyjUjzJMZwbovEnT5yHTW6g==
   dependencies:
-    "@types/prop-types" "*"
-    "@types/scheduler" "*"
     csstype "^3.0.2"
 
 "@types/resolve@1.17.1":
@@ -66,11 +59,6 @@
   integrity sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==
   dependencies:
     "@types/node" "*"
-
-"@types/scheduler@*":
-  version "0.16.2"
-  resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.2.tgz#1a62f89525723dde24ba1b01b092bf5df8ad4d39"
-  integrity sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==
 
 builtin-modules@^3.0.0:
   version "3.2.0"


### PR DESCRIPTION
The PR provides React v19 and React Router v7 support and fixes #26.

The changes have been tested in a large scale app that uses React 19 and React Router 7.